### PR TITLE
add µcad glossary (and link checker)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
     - name: Install ninja-build
       run: sudo apt-get install -y ninja-build
-    - name: Install lychee
-      run: cargo install lychee
     - uses: actions/checkout@v4
       with:
         submodules: 'true'
@@ -26,8 +24,6 @@ jobs:
       run: cargo build --verbose
     - name: Run clippy
       run: cargo clippy --verbose
-    - name: Run lychee
-      run: lychee --exclude-path target --exclude-path thirdparty .
 
   test:
     runs-on: ubuntu-latest
@@ -40,3 +36,15 @@ jobs:
         submodules: 'true'
     - name: Run tests
       run: cargo test --verbose
+
+  test-links:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install lychee
+      run: cargo install lychee
+    - uses: actions/checkout@v4
+    - uses: lycheeverse/lychee-action@v2.2.0
+    - name: Test Links
+      run: lychee --exclude-path target --exclude-path thirdparty .
+    

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,10 +13,12 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    
     steps:
-    - name: Install dependencies
+    - name: Install ninja-build
       run: sudo apt-get install -y ninja-build
+    - name: Install lychee
+      run: cargo install lychee
     - uses: actions/checkout@v4
       with:
         submodules: 'true'
@@ -24,9 +26,10 @@ jobs:
       run: cargo build --verbose
     - name: Run clippy
       run: cargo clippy --verbose
+    - name: Run lychee
+      run: lychee --exclude-path target --exclude-path thirdparty .
 
   test:
-
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ The STL file can now be loaded in a slicer program like [Cura](https://ultimaker
   - [`microcad-lang` module](https://docs.rs/microcad-lang)
   - [`microcad-core` module](https://docs.rs/microcad-core)
   - [`microcad-export` module](https://docs.rs/microcad-export)
+- [Glossary](doc/GLOSSARY.md)
 
 ## Contribute
 

--- a/doc/CONCEPTS.md
+++ b/doc/CONCEPTS.md
@@ -9,7 +9,7 @@ The processing of *µcad* source code files into output files can be divided int
 
 ### Parsing Phase
 
-In the parsing phase the source files are read into a *syntax tree* by using the [*µcad* grammar](lang/grammar.pest).
+In the parsing phase the source files are read into a *syntax tree* by using the [*µcad* grammar](../lang/grammar.pest).
 Any errors which occur within the parsing phase are related to file access or syntax.
 
 ### Evaluation Phase

--- a/doc/GLOSSARY.md
+++ b/doc/GLOSSARY.md
@@ -1,13 +1,23 @@
 # µcad Glossary
 
-| Term(s)                | Description                                                                               | Reference |
-| ---------------------- | ----------------------------------------------------------------------------------------- | --------- |
-| unit bundle            | Using one unit for an array of values                                                     |           |
-| parameter multiplicity | Calling a method multiple times by given arrays for parameters which usually are single   |           |
-| tuple                  | List of named values                                                                      |           |
-| module                 | Bundles a namespace, polymorph initializers and code (including functions) into one scope |           |
-| namespace              | Name scope with a public interface and internal elements                                  |           |
-| initializer, init      | Method that initializes a module with parameters (implicitly or explicitly)               |           |
-| statement              | Command to evaluate                                                                       |           |
-| primitive types        | Builtin µcad types                                                                        |           |
-| vec, vector, array     | Ordered list of values                                                                    |           |
+| Term(s)                | Alternative(s) | Description                                                                               | Reference |
+| ---------------------- | -------------- | ----------------------------------------------------------------------------------------- | --------- |
+| `difference`           |                | Geometrical difference of multiple objects                                                |           |
+| explicit initializer   |                | Function which initializes a module by parameters                                         |           |
+| field                  | member         | Top level member variables and parameters of a module                                     |           |
+| implicit initializer   | `init`         | Parameter list without code to initialize a module                                        |           |
+| initializer            |                | Method that initializes a module with parameters (implicitly or explicitly)               |           |
+| intersection           | `intersect`    | Geometrical intersection of multiple objects                                              |           |
+| `module`               |                | Bundles a namespace, polymorph initializers and code (including functions) into one scope |           |
+| `namespace`            |                | Name scope with a public interface and internal elements                                  |           |
+| parameter multiplicity |                | Calling a method multiple times by given arrays for parameters which usually are single   |           |
+| post-initialization    |                | Code executed after module initialization                                                 |           |
+| pre-initialization     |                | Code executed before module initialization                                                |           |
+| primitive types        |                | Builtin µcad types                                                                        |           |
+| public                 | `pub`          | Outside visibility of namespaces, modules, functions and fields                           |           |
+| statement              |                | Command to evaluate                                                                       |           |
+| tuple                  |                | List of named values                                                                      |           |
+| `union`                |                | Merge of two geometrical object into one                                                  |           |
+| unit bundle            |                | Using one unit for an array of values                                                     |           |
+| unit types             |                | Data types defined by type names or units                                                 |           |
+| vector                 | `Vec`, array   | Ordered list of values                                                                    |           |

--- a/doc/GLOSSARY.md
+++ b/doc/GLOSSARY.md
@@ -1,23 +1,23 @@
 # µcad Glossary
 
-| Term(s)                | Alternative(s) | Description                                                                               | Reference |
-| ---------------------- | -------------- | ----------------------------------------------------------------------------------------- | --------- |
-| `difference`           |                | Geometrical difference of multiple objects                                                |           |
-| explicit initializer   |                | Function which initializes a module by parameters                                         |           |
-| field                  | member         | Top level member variables and parameters of a module                                     |           |
-| implicit initializer   | `init`         | Parameter list without code to initialize a module                                        |           |
-| initializer            |                | Method that initializes a module with parameters (implicitly or explicitly)               |           |
-| intersection           | `intersect`    | Geometrical intersection of multiple objects                                              |           |
-| `module`               |                | Bundles a namespace, polymorph initializers and code (including functions) into one scope |           |
-| `namespace`            |                | Name scope with a public interface and internal elements                                  |           |
-| parameter multiplicity |                | Calling a method multiple times by given arrays for parameters which usually are single   |           |
-| post-initialization    |                | Code executed after module initialization                                                 |           |
-| pre-initialization     |                | Code executed before module initialization                                                |           |
-| primitive types        |                | Builtin µcad types                                                                        |           |
-| public                 | `pub`          | Outside visibility of namespaces, modules, functions and fields                           |           |
-| statement              |                | Command to evaluate                                                                       |           |
-| tuple                  |                | List of named values                                                                      |           |
-| `union`                |                | Merge of two geometrical object into one                                                  |           |
-| unit bundle            |                | Using one unit for an array of values                                                     |           |
-| unit types             |                | Data types defined by type names or units                                                 |           |
-| vector                 | `Vec`, array   | Ordered list of values                                                                    |           |
+| Term(s)                                                           | Alternative(s)     | Description                                                                               |
+| ----------------------------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------- |
+| `difference`                                                      |                    | Geometrical difference of multiple objects                                                |
+| [explicit initializer](modules/init.md#explicit-initializer)      |                    | Function which initializes a module by parameters                                         |
+| field                                                             | member             | Top level member variables and parameters of a module                                     |
+| [implicit initializer](modules/init.md#implicit-initializer)      | `init`             | Parameter list without code to initialize a module                                        |
+| [initializer](modules/init.md#module-initializers)                | module initializer | Method that initializes a module with parameters (implicitly or explicitly)               |
+| intersection                                                      | `intersect`        | Geometrical intersection of multiple objects                                              |
+| `module`                                                          |                    | Bundles a namespace, polymorph initializers and code (including functions) into one scope |
+| [`namespace`](namespaces.md)                                      |                    | Name scope with a public interface and internal elements                                  |
+| [parameter multiplicity](parameter_multiplicity.md)               |                    | Calling a method multiple times by given arrays for parameters which usually are single   |
+| [post-initialization](modules/README.md#post-initialization-code) |                    | Code executed after module initialization                                                 |
+| [pre-initialization](modules/README.md#pre-initialization-code)   |                    | Code executed before module initialization                                                |
+| [primitive types](primitive_types.md)                             |                    | Builtin µcad types                                                                        |
+| public                                                            | `pub`              | Outside visibility of namespaces, modules, functions and fields                           |
+| statement                                                         |                    | Command to evaluate                                                                       |
+| [tuple](tuple.md)                                                 |                    | List of named values                                                                      |
+| `union`                                                           |                    | Merge of two geometrical object into one                                                  |
+| unit bundle                                                       |                    | Using one unit for an array of values                                                     |
+| [unit types](unit_types.md)                                       |                    | Data types defined by type names or units                                                 |
+| vector                                                            | `Vec`, array       | Ordered list of values                                                                    |

--- a/doc/GLOSSARY.md
+++ b/doc/GLOSSARY.md
@@ -1,0 +1,13 @@
+# µcad Glossary
+
+| Term(s)                | Description                                                                               | Reference |
+| ---------------------- | ----------------------------------------------------------------------------------------- | --------- |
+| unit bundle            | Using one unit for an array of values                                                     |           |
+| parameter multiplicity | Calling a method multiple times by given arrays for parameters which usually are single   |           |
+| tuple                  | List of named values                                                                      |           |
+| module                 | Bundles a namespace, polymorph initializers and code (including functions) into one scope |           |
+| namespace              | Name scope with a public interface and internal elements                                  |           |
+| initializer, init      | Method that initializes a module with parameters (implicitly or explicitly)               |           |
+| statement              | Command to evaluate                                                                       |           |
+| primitive types        | Builtin µcad types                                                                        |           |
+| vec, vector, array     | Ordered list of values                                                                    |           |

--- a/doc/modules/README.md
+++ b/doc/modules/README.md
@@ -1,5 +1,14 @@
 # Modules
 
+- [Modules](#modules)
+  - [Declaration](#declaration)
+    - [Pre-initialization code](#pre-initialization-code)
+    - [Explicit Initializers](#explicit-initializers)
+    - [Post-initialization code](#post-initialization-code)
+  - [Module Elements](#module-elements)
+  - [Examples](#examples)
+
+
 Modules in µcad are similar to so-called *classes* in other programming languages
 but also they differ quite a bit.
 


### PR DESCRIPTION
Wanna fix our future wording in a glossary.

See [`GLOSSARY.md`](https://github.com/Rustfahrtagentur/microcad/blob/pat/glossary/doc/GLOSSARY.md)