### PR TITLE
Micha/module call

### DIFF
--- a/builtin/context_builder.rs
+++ b/builtin/context_builder.rs
@@ -38,9 +38,9 @@ impl ContextBuilder {
         let context = Self::new(std_source_file.clone()).with_builtin()?.build();
         let namespace = context
             .current_source_file()
-            .expect("std library missing")
+            .expect("std library")
             .eval_as_namespace(&mut self.context, "std".into())
-            .expect("failure evaluating std library");
+            .expect("valid std library");
 
         self.context.add_source_file(std_source_file);
         self.context.add(Symbol::Namespace(namespace));

--- a/lang/eval/call/call_argument.rs
+++ b/lang/eval/call/call_argument.rs
@@ -14,6 +14,7 @@ impl CallArgument {
     pub fn eval_bool(&self, context: &mut EvalContext) -> EvalResult<bool> {
         match self.value.eval(context) {
             Ok(Value::Bool(cond)) => Ok(*cond),
+            Ok(Value::None) => Ok(false),
             Ok(value) => {
                 context.error(
                     self.src_ref(),

--- a/lang/eval/call/call_argument_list.rs
+++ b/lang/eval/call/call_argument_list.rs
@@ -12,6 +12,16 @@ impl CallArgumentList {
             .get_matching_arguments(&parameter_values)
     }
 
+    /// Get multiplicty of matching arguments from a parameter list
+    pub fn get_multi_matching_arguments(
+        &self,
+        context: &mut EvalContext,
+        parameters: &ParameterList) -> EvalResult<MultiArgumentMap> {
+            let parameter_values = ParameterValueList::from_parameter_list(parameters, context)?;
+            CallArgumentValueList::from_call_argument_list(self, context)?
+                .get_multi_matching_arguments(&parameter_values)    
+    }
+
     /// return a single argument
     pub fn get_single(&self) -> EvalResult<&CallArgument> {
         if self.len() == 1 {

--- a/lang/eval/call_stack.rs
+++ b/lang/eval/call_stack.rs
@@ -1,0 +1,81 @@
+// Copyright © 2024 The µcad authors <info@ucad.xyz>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Call stack
+
+use crate::{resolve::{FullyQualify, SymbolNode}, src_ref::{SrcRef, SrcReferrer}};
+
+use super::ArgumentMap;
+
+
+/// Stack frame for a single call
+/// 
+/// Multiplicity calls are separate into single calls
+#[derive(Debug, Clone)]
+pub struct CallStackFrame {
+    /// Symbol that was call
+    symbol_node: SymbolNode,
+
+    /// Call arguments
+    args: ArgumentMap,
+
+    /// Source code reference
+    src_ref: SrcRef,
+}
+
+impl CallStackFrame {
+    /// Construct a new stack frame
+    pub fn new(symbol_node: SymbolNode, args: ArgumentMap, src_ref: impl SrcReferrer) -> Self {
+        Self {
+            symbol_node,
+            args,
+            src_ref: src_ref.src_ref()
+        }
+    }
+
+    /// Pretty print single call stack frame
+    fn pretty_print(&self, f: &mut std::fmt::Formatter<'_>, source_by_hash: &impl super::GetSourceByHash, idx: usize) -> std::fmt::Result {
+        match self.symbol_node.full_name() {
+            Some(name) => writeln!(f, "{:>4}: {name}", idx)?,
+            None => writeln!(f, "{:>4}: {id}", idx, id = self.symbol_node.id())?,
+        };
+
+        if let Some(line_col) = self.src_ref.at() {
+            let source_file = source_by_hash.get_by_hash(self.src_ref.source_hash());
+            writeln!(f, "            at {filename}:{line_col}", 
+                filename = source_file
+                    .as_ref()
+                    .map(|sf| sf.filename_as_str())
+                    .unwrap_or(crate::syntax::SourceFile::NO_FILE), 
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+
+/// Call stack
+#[derive(Default, Debug, Clone)]
+pub struct CallStack(Vec<CallStackFrame>);
+
+impl CallStack {
+    /// Push to stack
+    pub fn push(&mut self, symbol_node: SymbolNode, args: ArgumentMap, src_ref: impl SrcReferrer) {
+        self.0.push(CallStackFrame::new(symbol_node, args, src_ref))
+    }
+
+    /// Pop from stack
+    pub fn pop(&mut self) {
+        self.0.pop();
+    }
+
+    /// Pretty print stack
+    pub fn pretty_print(&self, f: &mut std::fmt::Formatter<'_>, source_by_hash: &impl super::GetSourceByHash) -> std::fmt::Result {
+        for (idx, call_stack_frame) in self.0.iter().enumerate() {
+            call_stack_frame.pretty_print(f, source_by_hash, idx)?;
+        }
+        Ok(())
+    }
+}
+

--- a/lang/eval/eval_context.rs
+++ b/lang/eval/eval_context.rs
@@ -1,7 +1,7 @@
 // Copyright © 2024 The µcad authors <info@ucad.xyz>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use crate::{diag::*, eval::*, resolve::*, syntax::*, Id};
+use crate::{diag::*, eval::*, resolve::*, syntax::*, eval::call_stack::CallStack, Id};
 
 use log::*;
 
@@ -14,6 +14,8 @@ pub struct EvalContext {
     symbols: SymbolMap,
     /// Stack of currently opened scopes with local symbols while evaluation
     local_stack: LocalStack,
+    /// Call stack
+    call_stack: CallStack,
     /// Source file cache containing all source files loaded in the context and their syntax trees
     source_cache: SourceCache,
     /// Source file diagnostics
@@ -69,6 +71,7 @@ impl EvalContext {
             symbols,
             diag_handler: Default::default(),
             local_stack: Default::default(),
+            call_stack: Default::default(),
             output,
         }
     }
@@ -115,6 +118,16 @@ impl EvalContext {
     /// Remove all local variables in the current scope and close it
     pub fn close_scope(&mut self) {
         self.local_stack.close_scope();
+    }
+
+    /// Push a call to stack
+    pub fn push_call(&mut self, symbol_node: SymbolNode, args: ArgumentMap, src_ref: impl SrcReferrer) {
+        self.call_stack.push(symbol_node, args, src_ref)
+    }
+
+    /// Pop a call from stack
+    pub fn pop_call(&mut self) {
+        self.call_stack.pop();
     }
 
     /// fetch global symbol from symbol map

--- a/lang/eval/eval_error.rs
+++ b/lang/eval/eval_error.rs
@@ -105,7 +105,7 @@ pub enum EvalError {
     SymbolNotFound(QualifiedName),
 
     /// Symbol not found (retry to load from external)
-    #[error("Symbol {0} must be loaded from {1:?}")]
+    #[error("Symbol {0} must be loaded from {1}")]
     SymbolMustBeLoaded(QualifiedName, std::path::PathBuf),
 
     /// Symbol is not a value
@@ -254,6 +254,14 @@ pub enum EvalError {
     /// Can't find a project file by it's qualified name
     #[error("Parsing error {0}")]
     ParseError(#[from] ParseError),
+
+    /// Statement is not supported in this context
+    #[error("Statement not supported: {0}")]
+    StatementNotSupported(Statement),
+
+    /// Properties are not initialized
+    #[error("Properties have not been initialized: {0:?}")]
+    UninitializedProperties(Vec<Id>),
 }
 
 /// Result type of any evaluation

--- a/lang/eval/mod.rs
+++ b/lang/eval/mod.rs
@@ -8,6 +8,7 @@ mod body;
 mod builtin_function;
 mod builtin_module;
 mod call;
+mod call_stack;
 mod eval_context;
 mod eval_error;
 mod expression;

--- a/lang/grammar.pest
+++ b/lang/grammar.pest
@@ -357,7 +357,8 @@ tag_list = _{ tag ~ (ws+ ~ tag)* }
 //`r: Length`: error # Default value is required
 //`r: Length = math::pi`: ok # Type specifier + Default value from constant
 //`r`: error # neither type specifier or default value
-assignment = { identifier ~ ws* ~ type_annotation? ~ ws* ~ "=" ~ ws* ~ expression }
+//`pub r = 5.0mm`: Make value of assignment public
+assignment = { (visibility ~ ws*)? ~ identifier ~ ws* ~ type_annotation? ~ ws* ~ "=" ~ ws* ~ expression }
 
 assignment_statement = _{ assignment ~ ws* ~ ";" }
 

--- a/lang/objects/algorithm.rs
+++ b/lang/objects/algorithm.rs
@@ -95,7 +95,7 @@ pub fn complement() -> ObjectNode {
 pub fn binary_op(op: BooleanOp, lhs: ObjectNode, rhs: ObjectNode) -> ObjectNode {
     assert!(lhs != rhs, "lhs and rhs must be distinct.");
     let root = ObjectNode::new(ObjectNodeInner::Algorithm(Rc::new(op)));
-    let group = crate::objects::empty_group();
+    let group = crate::objects::empty_object();
     group.append(lhs);
     group.append(rhs);
 

--- a/lang/objects/boolean_op.rs
+++ b/lang/objects/boolean_op.rs
@@ -15,7 +15,7 @@ impl Algorithm for BooleanOp {
         let geometries: Vec<_> = parent
             .children()
             .filter_map(|child| match &*child.borrow() {
-                ObjectNodeInner::Group(_) => {
+                ObjectNodeInner::Object(_) => {
                     BooleanOp::Union.render_into_geometry2d(renderer, child.clone())
                 }
                 ObjectNodeInner::Primitive2D(renderable) => {
@@ -43,7 +43,7 @@ impl Algorithm for BooleanOp {
         let geometries: Vec<_> = parent
             .children()
             .filter_map(|child| match &*child.borrow() {
-                ObjectNodeInner::Group(_) => {
+                ObjectNodeInner::Object(_) => {
                     BooleanOp::Union.process_geometry3d(renderer, child.clone())
                 }
                 ObjectNodeInner::Primitive3D(renderable) => {

--- a/lang/objects/transform.rs
+++ b/lang/objects/transform.rs
@@ -60,7 +60,7 @@ impl Algorithm for Transform {
         let geometries: Vec<_> = parent
             .children()
             .filter_map(|child| match &*child.borrow() {
-                ObjectNodeInner::Group(_) => {
+                ObjectNodeInner::Object(_) => {
                     BooleanOp::Union.render_into_geometry2d(renderer, child.clone())
                 }
                 ObjectNodeInner::Primitive2D(renderable) => {
@@ -88,7 +88,7 @@ impl Algorithm for Transform {
         let geometries: Vec<_> = parent
             .children()
             .filter_map(|child| match &*child.borrow() {
-                ObjectNodeInner::Group(_) => {
+                ObjectNodeInner::Object(_) => {
                     BooleanOp::Union.render_into_geometry3d(renderer, child.clone())
                 }
                 ObjectNodeInner::Primitive3D(renderable) => {

--- a/lang/parse/call.rs
+++ b/lang/parse/call.rs
@@ -93,7 +93,7 @@ fn call() {
 
     let call = Call::parse(pair).expect("test error");
 
-    assert_eq!(call.name, QualifiedName::from("foo"));
+    assert_eq!(call.name, "foo".into());
     assert_eq!(call.argument_list.len(), 4);
 
     // Count named arguments

--- a/lang/parse/type.rs
+++ b/lang/parse/type.rs
@@ -51,8 +51,8 @@ fn named_tuple_type() {
         type_annotation.ty(),
         Type::NamedTuple(NamedTupleType(
             vec![
-                (Identifier::from("x"), Type::Integer),
-                (Identifier::from("y"), Type::String)
+                ("x".into(), Type::Integer),
+                ("y".into(), Type::String)
             ]
             .into_iter()
             .collect()

--- a/lang/resolve/symbol_node.rs
+++ b/lang/resolve/symbol_node.rs
@@ -3,7 +3,7 @@ use custom_debug::Debug;
 use log::*;
 
 /// Symbol node
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SymbolNode {
     /// Symbol definition
     pub def: SymbolDefinition,

--- a/lang/src_ref/mod.rs
+++ b/lang/src_ref/mod.rs
@@ -115,13 +115,7 @@ impl SrcRef {
     pub fn merge(lhs: impl SrcReferrer, rhs: impl SrcReferrer) -> SrcRef {
         match (lhs.src_ref(), rhs.src_ref()) {
             (SrcRef(Some(lhs)), SrcRef(Some(rhs))) => {
-                let source_file_hash = {
-                    if lhs.source_file_hash != rhs.source_file_hash {
-                        todo!("Implement SrcRef with different files")
-                    } else {
-                        lhs.source_file_hash
-                    }
-                };
+                let source_file_hash = lhs.source_file_hash;
 
                 // TODO Not sure if this is correct.
                 // Can we actually merge two ranges of SrcRef?

--- a/lang/syntax/module/module_definition.rs
+++ b/lang/syntax/module/module_definition.rs
@@ -24,6 +24,7 @@ impl ModuleDefinition {
         Inits::new(self)
     }
 
+    /// Find a matching initializer for call argument list
     fn find_matching_initializer(&self, args: &CallArgumentList, context: &mut EvalContext) -> Option<(&ModuleInitDefinition, MultiArgumentMap)> {
         self.inits().find_map(|init| {
             if let Ok(arg_map) = args.get_multi_matching_arguments(context, &init.parameters) {
@@ -34,9 +35,9 @@ impl ModuleDefinition {
         })
     }
 
+    /// Try to evaluate a single call to an object
     fn eval_to_node<'a>(&'a self, args: &ArgumentMap, init: Option<&'a ModuleInitDefinition>, context: &mut EvalContext) -> EvalResult<ObjectNode> {
         let mut props = SortedValueList::from_parameter_list(&self.parameters, context)?;
-
 
         use crate::objects::*;
 
@@ -61,7 +62,6 @@ impl ModuleDefinition {
         };
 
         // At this point, all properties must have a value 
-    
         let mut nodes = Vec::new();
 
         for statement in &self.body.statements {
@@ -72,10 +72,7 @@ impl ModuleDefinition {
                     context.add_local_value(id.clone(), value);
                 }
                 Statement::Expression(expression) => {
-                    match expression.eval(context)? {
-                        Value::Node(node) => nodes.push(node),
-                        _ => {}
-                    }
+                    if let Value::Node(node) = expression.eval(context)? { nodes.push(node) }
                 }
                 _ => {}
             }
@@ -86,7 +83,6 @@ impl ModuleDefinition {
         for node in nodes {
             object.append(node);
         }
-
 
         Ok(object)
     }

--- a/lang/syntax/module/module_definition.rs
+++ b/lang/syntax/module/module_definition.rs
@@ -3,7 +3,7 @@
 
 //! Module definition syntax element
 
-use crate::{eval::*, src_ref::*, syntax::*, value::Value};
+use crate::{diag::PushDiag, eval::*, objects::ObjectNode, src_ref::*, syntax::*, value::Value};
 
 /// Module definition
 #[derive(Clone, Debug)]
@@ -23,31 +23,173 @@ impl ModuleDefinition {
     pub fn inits(&self) -> Inits {
         Inits::new(self)
     }
-}
 
-impl ModuleInitDefinition {}
-
-impl CallTrait for std::rc::Rc<ModuleDefinition> {
-    fn call(&self, _args: &CallArgumentList, _context: &mut EvalContext) -> EvalResult<Value> {
-        todo!();
-        /*match self.inits().find_map(|init| {
-            if let Ok(arg_map) = args.get_matching_arguments(context, &init.parameters) {
+    fn find_matching_initializer(&self, args: &CallArgumentList, context: &mut EvalContext) -> Option<(&ModuleInitDefinition, MultiArgumentMap)> {
+        self.inits().find_map(|init| {
+            if let Ok(arg_map) = args.get_multi_matching_arguments(context, &init.parameters) {
                 Some((init, arg_map))
             } else {
                 None
             }
-        }) {
-            // We have found a matching initializer
-            Some((init, arg_map)) => {
-                init.body.statements.iter().for_each(|statement| {});
-            }
-            // We have not found a matching initializer, test if call arguments match parameter list
+        })
+    }
+
+    fn eval_to_node<'a>(&'a self, args: &ArgumentMap, init: Option<&'a ModuleInitDefinition>, context: &mut EvalContext) -> EvalResult<ObjectNode> {
+        let mut props = SortedValueList::from_parameter_list(&self.parameters, context)?;
+
+
+        use crate::objects::*;
+
+        context.open_scope();
+
+        // Create the object node from initializer if present
+        let object = match init {
+            Some(init) => init.eval_to_node(args, props, context)?,
             None => {
-                let _arg_map = args.get_matching_arguments(context, &self.parameters);
+                // Add values from argument map as local values
+                for (id, value) in args.iter() {
+                    props.assign_and_add_local_value(id, value.clone(), context);
+                }
+                if !props.is_complete() {
+                    use crate::diag::PushDiag;
+                    context.error(self, EvalError::UninitializedProperties(props.get_incomplete_ids()))?;
+                    return Ok(crate::objects::empty_object());
+                } 
+        
+                object(Object { props })
             }
-        }*/
+        };
+
+        // At this point, all properties must have a value 
+    
+        let mut nodes = Vec::new();
+
+        for statement in &self.body.statements {
+            match statement {
+                Statement::Assignment(assignment) => {
+                    let id = assignment.name.id();
+                    let value = assignment.value.eval(context)?;
+                    context.add_local_value(id.clone(), value);
+                }
+                Statement::Expression(expression) => {
+                    match expression.eval(context)? {
+                        Value::Node(node) => nodes.push(node),
+                        _ => {}
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        context.close_scope();
+
+        for node in nodes {
+            object.append(node);
+        }
+
+
+        Ok(object)
+    }
+
+    /// Evaluate the call of a module
+    /// 
+    /// The evaluation considers multiplicity, which means that multiple nodes maybe created.
+    /// 
+    /// Example:
+    /// Consider the `module a(b: Scalar) { }`.
+    /// Calling the module `a([1.0, 2.0])` results in two nodes with `b = 1.0` and `b = 2.0`, respectively.
+    pub fn eval_call(&self, args: &CallArgumentList, context: &mut EvalContext) -> EvalResult<Vec<ObjectNode>> {
+        let mut nodes = Vec::new();
+
+        match self.find_matching_initializer(args, context) {
+            Some((init, multi_args)) => {
+            // We have a found a matching initializer. Evaluate each argument combination into a node 
+            for args in multi_args.combinations() {
+                    nodes.push(self.eval_to_node(&args, Some(init), context)?);
+                }
+            }
+            None => {
+                match args.get_multi_matching_arguments(context, &self.parameters) {
+                    Ok(multi_args) => {
+                        for args in multi_args.combinations() {
+                            nodes.push(self.eval_to_node(&args, None, context)?);
+                        }        
+                    }
+                    Err(err) => {
+                        context.error(self, err)?;
+                    }   
+                }
+            }
+        }
+
+
+        Ok(nodes)
     }
 }
+
+
+
+/// A list of module property values
+/// 
+/// It is required that properties are always sorted by their id. 
+#[derive(Clone, Default, Debug)]
+pub struct SortedValueList(Vec<(crate::Id, Value)>);
+
+impl SortedValueList {
+    /// Create initial property list by evaluating parameter list
+    pub fn from_parameter_list(parameter_list: &ParameterList, context: &mut EvalContext) -> EvalResult<Self> {
+        let mut props = Vec::new();
+        for parameter in parameter_list.iter() {
+            props.push((parameter.name.id().clone(), parameter.eval_default_value(context)?));
+        }
+
+        props.sort_by(|(lhs, _), (rhs, _)| lhs.cmp(rhs));
+
+        Ok(Self(props))
+    }
+
+    /// Test if each property has a value
+    pub fn is_complete(&self) -> bool {
+        self.0.iter().all(|(_, value)| !value.is_invalid())
+    }
+
+    /// Get index of item
+    pub fn get_index(&self, id: &crate::Id) -> Result<usize, usize> {
+        self.0.binary_search_by(|(prop_id, _)| prop_id.cmp(id))
+    }
+
+    /// Get value at id
+    pub fn get_value(&self, id: &crate::Id) -> Option<&Value> {
+        match self.get_index(id) {
+            Ok(index) => self.0.get(index).map(|p| &p.1),
+            Err(_) => None,
+        }
+    }
+
+    /// Get mutable value at id
+    pub fn get_value_mut(&mut self, id: &crate::Id) -> Option<&mut Value> {
+        match self.get_index(id) {
+            Ok(index) => self.0.get_mut(index).map(|p| &mut p.1),
+            Err(_) => None,
+        }
+    }
+
+    /// Get all ids where `value == Value::None`
+    pub fn get_incomplete_ids(&self) -> Vec<crate::Id> {
+        self.0.iter().filter_map(|(id, value)| if value.is_invalid() { Some(id.clone()) } else {None}).collect()
+    }
+
+    /// Assign the new value to the respective id if present and add as local value to the context 
+    pub fn assign_and_add_local_value(&mut self, id: &crate::Id, value: Value, context: &mut EvalContext) {
+        if let Some(prop_value) = self.get_value_mut(id) {
+            *prop_value = value.clone();
+        }
+        
+        // The result of the assignment becomes a local value, too
+        context.add_local_value(id.clone(), value);
+    }
+}
+
 
 /// Iterator over modules init statements
 pub struct Inits<'a>(std::slice::Iter<'a, Statement>);

--- a/lang/syntax/module/module_init_definition.rs
+++ b/lang/syntax/module/module_init_definition.rs
@@ -47,10 +47,7 @@ impl ModuleInitDefinition {
                     props.assign_and_add_local_value(id, value, context);
                 }
                 Statement::Expression(expression) => {
-                    match expression.eval(context)? {
-                        Value::Node(node) => nodes.push(node),
-                        _ => {}
-                    }
+                    if let Value::Node(node) = expression.eval(context)? { nodes.push(node) }
                 }
                 _ => {
                     context.error(self, EvalError::StatementNotSupported(statement.clone()))?;

--- a/lang/syntax/parameter/mod.rs
+++ b/lang/syntax/parameter/mod.rs
@@ -5,7 +5,7 @@
 
 mod parameter_list;
 
-use crate::{ord_map::*, src_ref::*, syntax::*, ty::*};
+use crate::{diag::PushDiag, eval::{EvalContext, EvalError}, ord_map::*, src_ref::*, syntax::*, ty::*, value::Value};
 
 pub use parameter_list::*;
 
@@ -36,6 +36,27 @@ impl Parameter {
             default_value,
             src_ref,
         }
+    }
+
+    /// Evaluate default value considering specified type
+    pub fn eval_default_value(&self, context: &mut EvalContext) -> crate::eval::EvalResult<Value>  {
+        use crate::eval::Eval;
+
+        match (&self.specified_type, &self.default_value) {
+            (Some(specified_type), Some(default_value)) => {
+                let value = default_value.eval(context)?;
+                if specified_type.ty() != value.ty() {
+                    context.error(self.src_ref.clone(), EvalError::ParameterTypeMismatch { name: self.name.clone(), expected: specified_type.ty(), found: value.ty() })?;
+                    Ok(Value::None)
+                } else {
+                    Ok(value)
+                }
+            }
+            (None, Some(default_value)) => Ok(default_value.eval(context)?),
+            _ => Ok(Value::None)
+        }
+
+
     }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -150,11 +150,25 @@ fn module_implicit_init_call() {
 
     assert_eq!(nodes.len(), 1, "There should be one node");
 
+    fn check_node_property_b(node: &objects::ObjectNode, value: f64) {
+        if let objects::ObjectNodeInner::Object(ref object) = *node.borrow() {
+            assert_eq!(object.get_property_value(&"b".into()).expect("Property `b`"), &value::Value::Scalar(src_ref::Refer::none(value)));
+        } else {
+            panic!("Object node expected")
+        }
+    }
+
     // Test if resulting object node has property `b` with value `3.0`
     use microcad_lang::*;
-    if let objects::ObjectNodeInner::Object(ref object) = *nodes.first().expect("Node expected").borrow() {
-        assert_eq!(object.get_property_value(&"b".into()).expect("Property `b`"), &value::Value::Scalar(src_ref::Refer::none(3.0)));
-    } else {
-        panic!("Object node expected")
-    }
+    check_node_property_b(nodes.first().expect("Node expected"), 3.0);
+
+    // Call module `a` with `b = [1.0, 2.0]` (multiplicity)
+    let nodes = module_definition
+        .eval_call(&call_argument_list("b = [1.0, 2.0]"), &mut context)
+        .expect("Valid nodes");
+
+    assert_eq!(nodes.len(), 2, "There should be two nodes");
+
+    check_node_property_b(nodes.first().expect("Node expected"), 1.0);
+    check_node_property_b(nodes.get(1).expect("Node expected"), 2.0);
 }

--- a/tests/test_cases/syntax/module/explicit_init.µcad
+++ b/tests/test_cases/syntax/module/explicit_init.µcad
@@ -1,7 +1,5 @@
-use __builtin::*;
-
-// Define a module `circle` with two Initializers
-module circle {
+// Define a module `circle` with two explicit initializers
+module circle(radius: Scalar) {
     init(r: Scalar) {
         radius = r;
     }
@@ -9,18 +7,4 @@ module circle {
     init(d: Scalar) {
         radius = d / 2.0;
     }
-
-    geo2d::circle(radius);
 }
-
-// Now, create two equal circles but with different initializations
-d_r = circle(r = 1.0);
-d_d = circle(d = 2.0);
-
-assert(d_r.radius == 1.0);
-assert(d_d.radius == 1.0);
-
-// Finally, insert the circles in the tree
-d_r;
-d_d;
-


### PR DESCRIPTION
The `CallStack` struct is ready, but I cannot use it because I can't reach the full symbol name when evaluating a module call with `eval_to_node`.