### PR TITLE
Micha/bugfixes

### DIFF
--- a/builtin/ops/hull.rs
+++ b/builtin/ops/hull.rs
@@ -15,12 +15,12 @@ impl Operation for Hull {
             let self_ = model.borrow();
 
             self_.children.iter().for_each(|model| {
-                let b = model.borrow();
-                let mat = b.output.local_matrix_2d();
+                let model_ = model.borrow();
+                let mat = model_.output.local_matrix_2d();
                 geometries.append(
                     model
                         .process_2d(model)
-                        .transformed_2d(&b.output.resolution, &mat),
+                        .transformed_2d(&model_.output.resolution, &mat),
                 );
             });
         }

--- a/examples/drill_plate.µcad
+++ b/examples/drill_plate.µcad
@@ -1,0 +1,14 @@
+use std::geo2d::*;
+use std::ops::*;
+
+#[color = "red"]
+sketch drill_plate(size = 100mm, hole_size = 10mm) {
+    difference() {
+        l = size/2 - hole_size;
+        rect(size);
+        translate(x = [-l,l], y = [-l,l])
+            circle(diameter = hole_size) 
+    }
+}
+
+drill_plate();

--- a/export/svg/attributes.rs
+++ b/export/svg/attributes.rs
@@ -19,12 +19,6 @@ pub enum SvgTagAttribute {
     /// `marker-end` attribute, e.g. for arrow heads.
     MarkerEnd(String),
 
-    /// Tag for font size in millimeters.
-    FontSizeMM(Scalar),
-
-    /// Fill attribute with a color.
-    Fill(Color),
-
     /// Style attribute: `style = "fill: skyblue; stroke: cadetblue; stroke-width: 2;"`.
     Style {
         fill: Option<Color>,
@@ -61,8 +55,6 @@ impl SvgTagAttribute {
         match &self {
             SvgTagAttribute::MarkerStart(_) => "marker-start",
             SvgTagAttribute::MarkerEnd(_) => "marker-end",
-            SvgTagAttribute::FontSizeMM(_) => "font-size",
-            SvgTagAttribute::Fill(_) => "fill",
             SvgTagAttribute::Style {
                 fill: _,
                 stroke: _,
@@ -81,8 +73,6 @@ impl std::fmt::Display for SvgTagAttribute {
             SvgTagAttribute::MarkerStart(marker_name) | SvgTagAttribute::MarkerEnd(marker_name) => {
                 format!("url(#{marker_name})")
             }
-            SvgTagAttribute::FontSizeMM(font_size) => format!("{}mm", *font_size as i64),
-            SvgTagAttribute::Fill(color) => color.to_svg_color(),
             SvgTagAttribute::Style {
                 fill,
                 stroke,
@@ -149,7 +139,11 @@ impl SvgTagAttributes {
     /// Apply SVG attributes from model attributes
     pub fn apply_from_model(mut self, model: &Model) -> Self {
         if let Some(color) = model.get_color() {
-            self = self.insert(SvgTagAttribute::Fill(color));
+            self = self.insert(SvgTagAttribute::Style {
+                fill: Some(color),
+                stroke: None,
+                stroke_width: None,
+            });
         }
 
         model

--- a/export/svg/primitives.rs
+++ b/export/svg/primitives.rs
@@ -203,9 +203,7 @@ impl WriteSvg for CenteredText {
         writer.open_tag(
             format!(r#"text x="{x}" y="{y}" dominant-baseline="middle" text-anchor="middle""#,)
                 .as_str(),
-            &attr
-                .clone()
-                .insert(attributes::SvgTagAttribute::FontSizeMM(self.font_size)),
+            attr,
         )?;
         writer.with_indent(&self.text)?;
         writer.close_tag("text")

--- a/lang/eval/attribute.rs
+++ b/lang/eval/attribute.rs
@@ -341,7 +341,6 @@ impl Eval<crate::model::Attributes> for AttributeList {
         Ok(Attributes(self.iter().try_fold(
             Vec::new(),
             |mut attributes, attribute| -> EvalResult<_> {
-                log::error!("{attribute:?}");
                 attributes.append(&mut attribute.eval(context)?);
                 Ok(attributes)
             },

--- a/lang/eval/attribute.rs
+++ b/lang/eval/attribute.rs
@@ -4,15 +4,15 @@
 use std::str::FromStr;
 
 use crate::{
+    Id,
     builtin::ExporterAccess,
     eval::{self, *},
     model::{Attributes, CustomCommand, ExportCommand, MeasureCommand, ResolutionAttribute},
     parameter,
     syntax::{self, *},
-    Id,
 };
 
-use microcad_core::{theme::Theme, Color, RenderResolution, Size2D};
+use microcad_core::{Color, RenderResolution, Size2D, theme::Theme};
 use thiserror::Error;
 
 /// Error type for attributes.
@@ -341,6 +341,7 @@ impl Eval<crate::model::Attributes> for AttributeList {
         Ok(Attributes(self.iter().try_fold(
             Vec::new(),
             |mut attributes, attribute| -> EvalResult<_> {
+                log::error!("{attribute:?}");
                 attributes.append(&mut attribute.eval(context)?);
                 Ok(attributes)
             },

--- a/lang/eval/statements/expression_statement.rs
+++ b/lang/eval/statements/expression_statement.rs
@@ -12,7 +12,10 @@ impl Eval for ExpressionStatement {
             Value::Models(mut models) => {
                 let attributes = self.attribute_list.eval(context)?;
                 models.iter_mut().for_each(|model| {
-                    model.borrow_mut().attributes = attributes.clone();
+                    model
+                        .borrow_mut()
+                        .attributes
+                        .append(&mut attributes.clone());
                 });
                 Ok(Value::Models(models))
             }

--- a/lang/model/attribute/mod.rs
+++ b/lang/model/attribute/mod.rs
@@ -75,6 +75,26 @@ impl Attribute {
     }
 }
 
+impl std::fmt::Display for Attribute {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "#[{id} = {value}]",
+            id = self.id(),
+            value = match &self {
+                // TODO: Do not use debug outputs, implement proper Display traits instead.
+                Attribute::Color(color) => format!("{color}"),
+                Attribute::Resolution(resolution) => format!("{resolution:?}"),
+                Attribute::Theme(theme) => theme.name.clone(),
+                Attribute::Size(size) => format!("{size:?}"),
+                Attribute::Export(export) => format!("{export:?}"),
+                Attribute::Measure(measure) => format!("{measure:?}"),
+                Attribute::Custom(command) => format!("{command:?}"),
+            }
+        )
+    }
+}
+
 /// This trait implementation is used to access values from an attribute.
 impl From<Attribute> for Value {
     fn from(value: Attribute) -> Self {

--- a/lang/model/builder.rs
+++ b/lang/model/builder.rs
@@ -117,7 +117,6 @@ impl ModelBuilder {
     /// Build a [`Model`].
     pub fn build(mut self) -> Model {
         if let Element::Workpiece(props) = &mut self.root.element.value {
-            log::trace!("Copy object properties:\n{}", self.properties);
             *props = self.properties;
         }
 

--- a/lang/model/mod.rs
+++ b/lang/model/mod.rs
@@ -236,10 +236,17 @@ impl std::fmt::Display for Model {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let depth = self.depth() * 2;
         writeln!(f, "{:depth$}{signature}", "", signature = self.signature())?;
-        for child in self.borrow().children.iter() {
-            write!(f, "{child}")?;
-        }
-        Ok(())
+        let self_ = self.borrow();
+
+        self_
+            .attributes
+            .iter()
+            .try_for_each(|attribute| writeln!(f, "{:depth$}{attribute}", ""))?;
+
+        self_
+            .children
+            .iter()
+            .try_for_each(|child| write!(f, "{child}"))
     }
 }
 

--- a/tools/cli/commands/watch.rs
+++ b/tools/cli/commands/watch.rs
@@ -30,10 +30,10 @@ impl RunCommand for Watch {
                     Ok(mut context) => {
                         // Re-evaluate context.
                         if let Ok(model) = context.eval() {
-                            let target_models =
-                                &export.target_models(&model, &config, context.exporters())?;
-
-                            export.export_targets(target_models)?;
+                            match export.target_models(&model, &config, context.exporters()) {
+                                Ok(target_models) => export.export_targets(&target_models)?,
+                                Err(err) => log::error!("{err}"),
+                            }
                         }
                     }
                     Err(err) => {


### PR DESCRIPTION
- [x] Fixed crash in CLI when output type of a model could not be determined
- [x] Remove Fill and FontSizeMM svg attributes, because according to SVG spec, style attribute is always preferenced.
- [x] Output attributes for Model
- [x] Fixed issue with missing attributes in models instantiated by workbench
- [x] Drill plate example 