### PR TITLE
rc: trace borrowing with feature `debug-cell`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ keywords = ["cad", "geometry", "3d", "printing", "cnc", "openscad"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace.dependencies]
+debug-cell = { git = "https://github.com/fightling/debug-cell.git" }
 microcad-core = { path = "core", version = "0.1.0" }
 microcad-import = { path = "import", version = "0.1.0" }
 microcad-export = { path = "export", version = "0.1.0" }

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -35,11 +35,13 @@ color-print = { version = "0.3", optional = true }
 microcad-core = { workspace = true }
 custom_debug = "0.6.2"
 derive_more = { version = "2.0.1", features = ["deref", "deref_mut"] }
+debug-cell = { workspace = true, optional = true }
 
 [features]
 default = ["geo3d", "ansi-color"]
 geo3d = []
 ansi-color = ["dep:color-print"]
+debug-cell = ["dep:debug-cell"]
 
 [lints.rust]
 missing_docs = "warn"

--- a/lang/rc.rs
+++ b/lang/rc.rs
@@ -6,14 +6,20 @@
 use derive_more::{Deref, DerefMut};
 pub use std::rc::Rc;
 
+#[cfg(feature = "debug-cell")]
+use debug_cell::RefCell;
+
+#[cfg(not(feature = "debug-cell"))]
+use std::cell::RefCell;
+
 /// Just a short cut definition
-#[derive(Debug, Deref, DerefMut)]
-pub struct RcMut<T>(Rc<std::cell::RefCell<T>>);
+#[derive(Deref, DerefMut)]
+pub struct RcMut<T>(Rc<RefCell<T>>);
 
 impl<T> RcMut<T> {
     /// Create new instance
     pub fn new(t: T) -> Self {
-        Self(Rc::new(std::cell::RefCell::new(t)))
+        Self(Rc::new(RefCell::new(t)))
     }
 }
 
@@ -26,5 +32,11 @@ impl<T> Clone for RcMut<T> {
 impl<T> From<T> for RcMut<T> {
     fn from(value: T) -> Self {
         RcMut::new(value)
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for RcMut<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("RcMut").field(&self.0.borrow()).finish()
     }
 }


### PR DESCRIPTION
activating feature `debug-cell` uses modified crate [`debug-cell`](https://crates.io/crates/debug-cell) to trace borrowing collisions.